### PR TITLE
Add Lando support

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,30 @@
+name: wordpress
+recipe: wordpress
+config:
+    webroot: web
+    via: nginx
+    database: mariadb
+    php: 7.2
+    xdebug: true
+
+services:
+    appserver:
+        run:
+            - /bin/sh -c "/app/.lando/scripts/local-config-files.sh"
+            - /bin/sh -c "/app/.lando/scripts/install-platformsh-cli.sh"
+            - /bin/sh -c "/app/.lando/scripts/git-clean.sh"
+            - cd /app && composer install
+
+tooling:
+    git-clean:
+        description: "Clean codebase. Removes untracked files from the working tree. Use with caution."
+        service: appserver
+        cmd: /bin/sh -c "/app/.lando/scripts/git-clean.sh"
+    platform:
+        description: "Run Platform.sh commands"
+        service: appserver
+        cmd: /var/www/.platformsh/bin/platform
+
+events:
+    post-db-import:
+        - appserver: /usr/local/bin/wp --allow-root cache flush

--- a/.lando/.bashrc
+++ b/.lando/.bashrc
@@ -1,0 +1,8 @@
+# BEGIN SNIPPET: Platform.sh CLI configuration
+HOME=${HOME:-'/var/www'}
+export PATH="$HOME/"'.platformsh/bin':"$PATH"
+if [ -f "$HOME/"'.platformsh/shell-config.rc' ]; then . "$HOME/"'.platformsh/shell-config.rc'; fi
+# END SNIPPET
+
+# Aliases.
+alias ls="ls -AFGl --color=auto"

--- a/.lando/example.env
+++ b/.lando/example.env
@@ -1,0 +1,6 @@
+# Platform.sh CLI - API Token.
+# Obtain a token: https://docs.platform.sh/gettingstarted/cli/api-tokens.html#obtaining-a-token
+PLATFORMSH_CLI_TOKEN=YOUR_TOKEN_HERE
+
+# Debugging.
+WP_DEBUG=true

--- a/.lando/example.wp-config-local.php
+++ b/.lando/example.wp-config-local.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Configuration overrides for local development.
+ *
+ * Rename this file to `wp-config-local.php` move to the project root.
+ *
+ * This file contains the following configurations:
+ *
+ * - MySQL settings
+ * - Redis settings
+ * - Secret keys
+ * - Debugging mode
+ *
+ * @link https://codex.wordpress.org/Editing_wp-config.php
+ *
+ * @package WordPress
+ */
+
+/**
+ * Lando services.
+ */
+if (getenv('LANDO_INFO')) {
+  $lando_info = json_decode(getenv('LANDO_INFO'), TRUE);
+
+  // MySQL settings for Lando database service.
+  define('DB_NAME', $lando_info['database']['creds']['database']);
+  define('DB_USER', $lando_info['database']['creds']['user']);
+  define('DB_PASSWORD', $lando_info['database']['creds']['password']);
+  define('DB_HOST', $lando_info['database']['internal_connection']['host']);
+  define('DB_CHARSET', 'utf8');
+  define('DB_COLLATE', '');
+
+  // Redis settings for Lando service.
+  if (isset($lando_info['cache'])) {
+    define('WP_REDIS_HOST', $lando_info['cache']['internal_connection']['host']);
+    define('WP_REDIS_PORT', $lando_info['cache']['internal_connection']['port']);
+  }
+}
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+define('AUTH_KEY',         'put your unique phrase here');
+define('SECURE_AUTH_KEY',  'put your unique phrase here');
+define('LOGGED_IN_KEY',    'put your unique phrase here');
+define('NONCE_KEY',        'put your unique phrase here');
+define('AUTH_SALT',        'put your unique phrase here');
+define('SECURE_AUTH_SALT', 'put your unique phrase here');
+define('LOGGED_IN_SALT',   'put your unique phrase here');
+define('NONCE_SALT',       'put your unique phrase here');
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the Codex.
+ *
+ * @link https://codex.wordpress.org/Debugging_in_WordPress
+ */
+define('WP_DEBUG', getenv('WP_DEBUG'));

--- a/.lando/scripts/git-clean.sh
+++ b/.lando/scripts/git-clean.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+git clean -d -x -ff --exclude=.env --exclude=wp-config-local.php --exclude=web/wp-content/uploads

--- a/.lando/scripts/install-platformsh-cli.sh
+++ b/.lando/scripts/install-platformsh-cli.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Install Platform.sh CLI.
+curl -sS https://platform.sh/cli/installer | php

--- a/.lando/scripts/local-config-files.sh
+++ b/.lando/scripts/local-config-files.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [ ! -f "~/.bashrc" ]; then
+  cp -v $LANDO_MOUNT/.lando/.bashrc ~/.bashrc
+fi
+
+if [ ! -f "$LANDO_MOUNT/.env" ]; then
+  cp -v $LANDO_MOUNT/.lando/example.env $LANDO_MOUNT/.env
+fi
+
+if [ ! -f "$LANDO_MOUNT/web/wp-config-local.php" ]; then
+  cp -v $LANDO_MOUNT/.lando/example.wp-config-local.php $LANDO_MOUNT/web/wp-config-local.php
+fi


### PR DESCRIPTION
* Adds a basic Lando configuration, ready to launch.
* Pre-configured to use Platform.sh API Token for CLI authentication.
* Makes Platform.sh CLI avaialble via `lando platform`