### PR TITLE
Disable cache when cookies are set

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -8,13 +8,8 @@
     upstream: "app:http"
     cache:
         enabled: true
-        # Base the cache on the session cookies. Ignore all other cookies.
-        cookies:
-            - '/^wordpress_logged_in_/'
-            - '/^wordpress_sec_/'
-            - 'wordpress_test_cookie'
-            - '/^wp-settings-/'
-            - '/^wp-postpass/'
+        # Base the cache on cookies.
+        cookies: ['*']
 
 "https://www.{default}/":
     type: redirect


### PR DESCRIPTION
Using a limited set of cookies breaks the reset password feature and possibly other features. This change effectively ignores the cache when cookies are set which should be the default (expected) behaviour.